### PR TITLE
[Feat] 메세지 템플릿 페이지 CRUD 적용

### DIFF
--- a/src/pages/MessageAddForm.jsx
+++ b/src/pages/MessageAddForm.jsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
-import "../styles/messageAddForm.css";
-import { useNavigate } from "react-router-dom";
+import { useState } from 'react';
+import '../styles/messageAddForm.css';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 const MessageAddForm = () => {
   const [formData, setFormData] = useState({
-    urgency: "",
+    urgency: '',
     repeatInterval: 300,
-    content: "",
+    content: '',
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
@@ -14,27 +15,27 @@ const MessageAddForm = () => {
   // 긴급도 태그 옵션
   const urgencyTypes = [
     {
-      id: "emergency",
-      label: "긴급",
-      color: "#FF4444",
-      bgColor: "#FFE6E6",
-      description: "즉시 확인이 필요한 중요한 메세지",
+      id: 'emergency',
+      label: '긴급',
+      color: '#FF4444',
+      bgColor: '#FFE6E6',
+      description: '즉시 확인이 필요한 중요한 메세지',
       defaultInterval: 30,
     },
     {
-      id: "normal",
-      label: "보통",
-      color: "#FF8C00",
-      bgColor: "#FFF3E6",
-      description: "일반적인 알림 메세지",
+      id: 'normal',
+      label: '보통',
+      color: '#FF8C00',
+      bgColor: '#FFF3E6',
+      description: '일반적인 알림 메세지',
       defaultInterval: 180,
     },
     {
-      id: "good",
-      label: "양호",
-      color: "#4CAF50",
-      bgColor: "#E8F5E8",
-      description: "격려와 안부를 위한 메세지",
+      id: 'good',
+      label: '양호',
+      color: '#4CAF50',
+      bgColor: '#E8F5E8',
+      description: '격려와 안부를 위한 메세지',
       defaultInterval: 300,
     },
   ];
@@ -67,25 +68,42 @@ const MessageAddForm = () => {
 
   const handleSubmit = async () => {
     if (!formData.urgency) {
-      alert("긴급도를 선택해주세요.");
+      alert('긴급도를 선택해주세요.');
       return;
     }
 
     if (!formData.content.trim()) {
-      alert("메세지 내용을 입력해주세요.");
+      alert('메세지 내용을 입력해주세요.');
       return;
     }
 
     setIsSubmitting(true);
 
     try {
-      // API 호출 시뮬레이션
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      // 긴급도 태그 옵션 → 백엔드 status 값으로 매핑
+      const urgencyMap = {
+        emergency: 'HIGH',
+        normal: 'MEDIUM',
+        good: 'LOW',
+      };
 
-      alert("메세지가 성공적으로 추가되었습니다!");
-      navigate("/list"); // 목록으로 돌아가기
+      const payload = {
+        status: urgencyMap[formData.urgency], // 상태
+        alertCycle: formData.repeatInterval, // 반복 주기
+        message: formData.content, // 메세지 내용
+        displayOrder: Date.now(),
+      };
+
+      const res = await axios.post(
+        `${import.meta.env.VITE_API_URL}/api/v1/template/guardian`,
+        payload,
+        { withCredentials: true }
+      );
+
+      alert('메세지가 성공적으로 추가되었습니다!');
+      navigate('/list');
     } catch (error) {
-      alert("메세지 추가에 실패했습니다. 다시 시도해주세요.");
+      alert('메세지 추가에 실패했습니다. 다시 시도해주세요.');
     } finally {
       setIsSubmitting(false);
     }
@@ -115,7 +133,7 @@ const MessageAddForm = () => {
               <div
                 key={type.id}
                 className={`urgency-tag ${type.id} ${
-                  formData.urgency === type.id ? "selected" : ""
+                  formData.urgency === type.id ? 'selected' : ''
                 }`}
                 onClick={() => handleUrgencySelect(type.id)}
               >
@@ -193,7 +211,7 @@ const MessageAddForm = () => {
           {selectedType && (
             <div className="template-suggestions">
               <div className="template-title">💡 추천 템플릿</div>
-              {selectedType.id === "emergency" && (
+              {selectedType.id === 'emergency' && (
                 <>
                   <div
                     className="template-item"
@@ -201,7 +219,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          "🚨 즉시 확인이 필요합니다. 안전을 위해 연락주세요!",
+                          '🚨 즉시 확인이 필요합니다. 안전을 위해 연락주세요!',
                       })
                     }
                   >
@@ -212,7 +230,7 @@ const MessageAddForm = () => {
                     onClick={() =>
                       setFormData({
                         ...formData,
-                        content: "⚠️ 긴급 상황입니다. 즉시 대응해주세요.",
+                        content: '⚠️ 긴급 상황입니다. 즉시 대응해주세요.',
                       })
                     }
                   >
@@ -220,14 +238,14 @@ const MessageAddForm = () => {
                   </div>
                 </>
               )}
-              {selectedType.id === "normal" && (
+              {selectedType.id === 'normal' && (
                 <>
                   <div
                     className="template-item"
                     onClick={() =>
                       setFormData({
                         ...formData,
-                        content: "💊 약 복용 시간입니다. 물과 함께 드세요.",
+                        content: '💊 약 복용 시간입니다. 물과 함께 드세요.',
                       })
                     }
                   >
@@ -239,7 +257,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          "🏥 건강 체크 시간이에요. 혈압을 측정해주세요.",
+                          '🏥 건강 체크 시간이에요. 혈압을 측정해주세요.',
                       })
                     }
                   >
@@ -247,7 +265,7 @@ const MessageAddForm = () => {
                   </div>
                 </>
               )}
-              {selectedType.id === "good" && (
+              {selectedType.id === 'good' && (
                 <>
                   <div
                     className="template-item"
@@ -255,7 +273,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          "😊 오늘 하루도 건강하게 보내세요! 항상 응원하고 있어요.",
+                          '😊 오늘 하루도 건강하게 보내세요! 항상 응원하고 있어요.',
                       })
                     }
                   >
@@ -267,7 +285,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          "💝 컨디션이 좋아 보여서 기뻐요. 계속 잘 지내세요!",
+                          '💝 컨디션이 좋아 보여서 기뻐요. 계속 잘 지내세요!',
                       })
                     }
                   >
@@ -282,7 +300,7 @@ const MessageAddForm = () => {
               <div className="preview-title">📱 환자 화면 미리보기</div>
               <div className="preview-message">{formData.content}</div>
               <div className="preview-meta">
-                {selectedType?.label} • {formatTime(formData.repeatInterval)}{" "}
+                {selectedType?.label} • {formatTime(formData.repeatInterval)}{' '}
                 반복
               </div>
             </div>
@@ -296,7 +314,7 @@ const MessageAddForm = () => {
             isSubmitting || !formData.urgency || !formData.content.trim()
           }
         >
-          {isSubmitting ? "메세지 추가 중..." : "메세지 추가 완료"}
+          {isSubmitting ? '메세지 추가 중...' : '메세지 추가 완료'}
         </button>
       </div>
     </div>

--- a/src/pages/MessageList.jsx
+++ b/src/pages/MessageList.jsx
@@ -1,89 +1,103 @@
-import React, { useState, useRef, useEffect } from "react";
-import "../styles/messageList.css";
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import '../styles/messageList.css';
 
 const MessageList = () => {
-  // 샘플 메세지 데이터
-  const [messages, setMessages] = useState([
-    {
-      id: 1,
-      content: "오늘 약 드셨나요? 건강이 최우선이에요!",
-      isEditing: false,
-    },
-    {
-      id: 2,
-      content: "물을 충분히 마시고 있는지 확인해주세요.",
-      isEditing: false,
-    },
-    {
-      id: 3,
-      content: "운동은 가볍게 산책부터 시작해보세요.",
-      isEditing: false,
-    },
-    {
-      id: 4,
-      content: "식사는 거르지 마시고 규칙적으로 해주세요.",
-      isEditing: false,
-    },
-    {
-      id: 5,
-      content: "혈압 측정하셨나요? 기록도 잊지 마세요.",
-      isEditing: false,
-    },
-  ]);
-
+  const [messages, setMessages] = useState([]);
   const [selectedItems, setSelectedItems] = useState(new Set());
   const [activeItemId, setActiveItemId] = useState(null);
-  const [draggedItem, setDraggedItem] = useState(null);
-  const [dragOverIndex, setDragOverIndex] = useState(null);
-  const [editingContent, setEditingContent] = useState("");
+  const [editingContent, setEditingContent] = useState('');
+  const navigate = useNavigate();
 
-  const dragItemRef = useRef(null);
-  const dragOverItemRef = useRef(null);
+  useEffect(() => {
+    axios
+      .get(`${import.meta.env.VITE_API_URL}/dev/session/getUserInfo`, {
+        withCredentials: true,
+      })
+      .then((res) => {
+        return axios.get(
+          `${import.meta.env.VITE_API_URL}/api/v1/template/guardian/list`,
+          { withCredentials: true }
+        );
+      })
+      .then((res) => {
+        const templates = res.data.data || [];
+        const mapped = templates.map((item) => ({
+          id: item.templateId,
+          content: item.message,
+          status: item.status,
+          isEditing: false,
+        }));
+        setMessages(mapped);
+      })
+      .catch((err) => {
+        console.error('메시지 불러오기 실패', err);
+      });
+  }, []);
 
-  // 전체 선택/해제
-  const handleSelectAll = checked => {
+  /** 전체 선택 */
+  const handleSelectAll = (checked) => {
     if (checked) {
-      setSelectedItems(new Set(messages.map(m => m.id)));
+      setSelectedItems(new Set(messages.map((m) => m.id)));
     } else {
       setSelectedItems(new Set());
     }
   };
 
-  // 개별 선택/해제
+  /** 개별 선택 */
   const handleSelectItem = (id, checked) => {
     const newSelected = new Set(selectedItems);
-    if (checked) {
-      newSelected.add(id);
-    } else {
-      newSelected.delete(id);
-    }
+    checked ? newSelected.add(id) : newSelected.delete(id);
     setSelectedItems(newSelected);
   };
 
-  // 선택된 항목들 삭제
-  const handleDeleteSelected = () => {
+  /** 선택 삭제 */
+  const handleDeleteSelected = async () => {
     if (selectedItems.size === 0) return;
+    if (!confirm(`선택한 ${selectedItems.size}개 삭제할까요?`)) return;
 
-    if (
-      confirm(`선택한 ${selectedItems.size}개의 메세지를 삭제하시겠습니까?`)
-    ) {
-      setMessages(messages.filter(m => !selectedItems.has(m.id)));
+    try {
+      for (let id of selectedItems) {
+        await axios.delete(
+          `${import.meta.env.VITE_API_URL}/api/v1/template/delete`,
+          {
+            data: { templateId: id },
+            withCredentials: true,
+          }
+        );
+      }
+      setMessages(messages.filter((m) => !selectedItems.has(m.id)));
       setSelectedItems(new Set());
+      alert('선택된 메시지가 삭제되었습니다.');
+    } catch (err) {
+      console.error(err);
     }
   };
 
-  // 개별 삭제
-  const handleDeleteItem = id => {
-    if (confirm("이 메세지를 삭제하시겠습니까?")) {
-      setMessages(messages.filter(m => m.id !== id));
+  /** 단일 삭제 */
+  const handleDeleteItem = async (id) => {
+    if (!confirm('삭제할까요?')) return;
+
+    try {
+      await axios.delete(
+        `${import.meta.env.VITE_API_URL}/api/v1/template/delete`,
+        {
+          data: { templateId: id },
+          withCredentials: true,
+        }
+      );
+      setMessages(messages.filter((m) => m.id !== id));
       setActiveItemId(null);
+    } catch (err) {
+      console.error(err);
     }
   };
 
-  // 편집 시작
+  /** 수정 시작 */
   const handleEditStart = (id, content) => {
     setMessages(
-      messages.map(m =>
+      messages.map((m) =>
         m.id === id ? { ...m, isEditing: true } : { ...m, isEditing: false }
       )
     );
@@ -91,225 +105,177 @@ const MessageList = () => {
     setActiveItemId(null);
   };
 
-  // 편집 저장
-  const handleEditSave = id => {
-    if (editingContent.trim() === "") {
-      alert("메세지 내용을 입력해주세요.");
+  /** 수정 저장 (PUT 요청) */
+  const handleEditSave = async (id) => {
+    if (!editingContent.trim()) {
+      alert('내용 입력 필요!');
       return;
     }
 
-    setMessages(
-      messages.map(m =>
-        m.id === id
-          ? { ...m, content: editingContent.trim(), isEditing: false }
-          : m
-      )
-    );
-    setEditingContent("");
-  };
+    const target = messages.find((m) => m.id === id);
+    try {
+      const res = await axios.put(
+        `${import.meta.env.VITE_API_URL}/api/v1/template/guardian`,
+        {
+          templateId: id,
+          status: target.status,
+          alertCycle: target.alertCycle,
+          message: editingContent.trim(),
+        },
+        { withCredentials: true }
+      );
 
-  // 편집 취소
-  const handleEditCancel = id => {
-    setMessages(
-      messages.map(m => (m.id === id ? { ...m, isEditing: false } : m))
-    );
-    setEditingContent("");
-  };
-
-  // 드래그 시작
-  const handleDragStart = (e, index) => {
-    setDraggedItem({ index, item: messages[index] });
-    e.dataTransfer.effectAllowed = "move";
-  };
-
-  // 드래그 오버
-  const handleDragOver = (e, index) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
-    setDragOverIndex(index);
-  };
-
-  // 드롭
-  const handleDrop = (e, dropIndex) => {
-    e.preventDefault();
-
-    if (draggedItem && draggedItem.index !== dropIndex) {
-      const newMessages = [...messages];
-      const draggedMessage = newMessages.splice(draggedItem.index, 1)[0];
-      newMessages.splice(dropIndex, 0, draggedMessage);
-      setMessages(newMessages);
+      setMessages(
+        messages.map((m) =>
+          m.id === id
+            ? { ...m, content: editingContent.trim(), isEditing: false }
+            : m
+        )
+      );
+      setEditingContent('');
+    } catch (err) {
+      console.error(err);
     }
-
-    setDraggedItem(null);
-    setDragOverIndex(null);
   };
 
-  // 외부 클릭 시 액션 버튼 숨김
-  useEffect(() => {
-    const handleClickOutside = event => {
-      if (!event.target.closest(".message-item")) {
-        setActiveItemId(null);
-      }
-    };
-
-    document.addEventListener("click", handleClickOutside);
-    return () => document.removeEventListener("click", handleClickOutside);
-  }, []);
+  /** 수정 취소 */
+  const handleEditCancel = (id) => {
+    setMessages(
+      messages.map((m) => (m.id === id ? { ...m, isEditing: false } : m))
+    );
+    setEditingContent('');
+  };
 
   const isAllSelected =
     messages.length > 0 && selectedItems.size === messages.length;
   const hasSelection = selectedItems.size > 0;
 
   return (
-    <>
-      <div className="message-management-container">
-        <div className="header-section">
-          <div className="header-content">
-            <h1 className="page-title">메세지 관리</h1>
-            <button
-              className="add-btn"
-              onClick={() => alert("메세지 추가 페이지로 이동")}
-            >
-              + 메세지 추가
-            </button>
-          </div>
+    <div className="message-management-container">
+      <div className="header-section">
+        <div className="header-content">
+          <h1 className="page-title">메세지 관리</h1>
+          <button className="add-btn" onClick={() => navigate('/add')}>
+            + 메세지 추가
+          </button>
+        </div>
 
-          {messages.length > 0 && (
-            <div className="bulk-actions">
-              <label className="select-all-wrapper">
+        {messages.length > 0 && (
+          <div className="bulk-actions">
+            <label className="select-all-wrapper">
+              <input
+                type="checkbox"
+                className="checkbox"
+                checked={isAllSelected}
+                onChange={(e) => handleSelectAll(e.target.checked)}
+              />
+              전체 선택
+            </label>
+
+            <button
+              className={`delete-selected-btn ${hasSelection ? 'active' : ''}`}
+              onClick={handleDeleteSelected}
+              disabled={!hasSelection}
+            >
+              선택 삭제 ({selectedItems.size})
+            </button>
+
+            <span className="message-count">{messages.length}/20</span>
+          </div>
+        )}
+      </div>
+
+      <div className="messages-container">
+        {messages.length === 0 ? (
+          <div className="empty-state">
+            <div className="empty-icon">💬</div>
+            <div className="empty-title">메세지가 없습니다</div>
+            <div className="empty-description">
+              환자에게 보여줄 메세지를 <br /> 추가해보세요!
+            </div>
+          </div>
+        ) : (
+          messages.map((message) => (
+            <div key={message.id} className="message-item">
+              <div className="message-content">
                 <input
                   type="checkbox"
-                  className="checkbox"
-                  checked={isAllSelected}
-                  onChange={e => handleSelectAll(e.target.checked)}
+                  className="message-checkbox"
+                  checked={selectedItems.has(message.id)}
+                  onChange={(e) =>
+                    handleSelectItem(message.id, e.target.checked)
+                  }
                 />
-                전체 선택
-              </label>
 
-              <button
-                className={`delete-selected-btn ${
-                  hasSelection ? "active" : ""
-                }`}
-                onClick={handleDeleteSelected}
-                disabled={!hasSelection}
-              >
-                선택 삭제 ({selectedItems.size})
-              </button>
+                {message.isEditing ? (
+                  <>
+                    <input
+                      type="text"
+                      className="message-input"
+                      value={editingContent}
+                      onChange={(e) => setEditingContent(e.target.value)}
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleEditSave(message.id);
+                        if (e.key === 'Escape') handleEditCancel(message.id);
+                      }}
+                    />
+                    <div className="edit-actions">
+                      <button
+                        className="edit-btn save-btn"
+                        onClick={() => handleEditSave(message.id)}
+                      >
+                        저장
+                      </button>
+                      <button
+                        className="edit-btn cancel-btn"
+                        onClick={() => handleEditCancel(message.id)}
+                      >
+                        취소
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div
+                      className="message-text"
+                      onClick={() =>
+                        setActiveItemId(
+                          activeItemId === message.id ? null : message.id
+                        )
+                      }
+                    >
+                      {message.content}
+                    </div>
 
-              <span className="message-count">{messages.length}/20</span>
-            </div>
-          )}
-        </div>
-
-        <div className="messages-container">
-          {messages.length === 0 ? (
-            <div className="empty-state">
-              <div className="empty-icon">💬</div>
-              <div className="empty-title">메세지가 없습니다</div>
-              <div className="empty-description">
-                환자에게 보여줄 메세지를
-                <br />
-                추가해보세요!
-              </div>
-            </div>
-          ) : (
-            messages.map((message, index) => (
-              <div
-                key={message.id}
-                className={`message-item ${
-                  draggedItem?.index === index ? "dragging" : ""
-                } ${dragOverIndex === index ? "drag-over" : ""}`}
-                draggable
-                onDragStart={e => handleDragStart(e, index)}
-                onDragOver={e => handleDragOver(e, index)}
-                onDrop={e => handleDrop(e, index)}
-                onDragEnd={() => {
-                  setDraggedItem(null);
-                  setDragOverIndex(null);
-                }}
-              >
-                <div className="message-content">
-                  <div className="drag-handle">⋮⋮</div>
-
-                  <input
-                    type="checkbox"
-                    className="message-checkbox"
-                    checked={selectedItems.has(message.id)}
-                    onChange={e =>
-                      handleSelectItem(message.id, e.target.checked)
-                    }
-                  />
-
-                  {message.isEditing ? (
-                    <>
-                      <input
-                        type="text"
-                        className="message-input"
-                        value={editingContent}
-                        onChange={e => setEditingContent(e.target.value)}
-                        autoFocus
-                        onKeyDown={e => {
-                          if (e.key === "Enter") handleEditSave(message.id);
-                          if (e.key === "Escape") handleEditCancel(message.id);
-                        }}
-                      />
-                      <div className="edit-actions">
-                        <button
-                          className="edit-btn save-btn"
-                          onClick={() => handleEditSave(message.id)}
-                        >
-                          저장
-                        </button>
-                        <button
-                          className="edit-btn cancel-btn"
-                          onClick={() => handleEditCancel(message.id)}
-                        >
-                          취소
-                        </button>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div
-                        className="message-text"
+                    <div
+                      className={`item-actions ${
+                        activeItemId === message.id ? 'active' : ''
+                      }`}
+                    >
+                      <button
+                        className="action-btn edit-action-btn"
                         onClick={() =>
-                          setActiveItemId(
-                            activeItemId === message.id ? null : message.id
-                          )
+                          handleEditStart(message.id, message.content)
                         }
                       >
-                        {message.content}
-                      </div>
-
-                      <div
-                        className={`item-actions ${
-                          activeItemId === message.id ? "active" : ""
-                        }`}
+                        수정
+                      </button>
+                      <button
+                        className="action-btn delete-action-btn"
+                        onClick={() => handleDeleteItem(message.id)}
                       >
-                        <button
-                          className="action-btn edit-action-btn"
-                          onClick={() =>
-                            handleEditStart(message.id, message.content)
-                          }
-                        >
-                          수정
-                        </button>
-                        <button
-                          className="action-btn delete-action-btn"
-                          onClick={() => handleDeleteItem(message.id)}
-                        >
-                          삭제
-                        </button>
-                      </div>
-                    </>
-                  )}
-                </div>
+                        삭제
+                      </button>
+                    </div>
+                  </>
+                )}
               </div>
-            ))
-          )}
-        </div>
+            </div>
+          ))
+        )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,14 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: "0.0.0.0",
+    host: '0.0.0.0',
     allowedHosts: [
-      "host.docker.internal", // Docker 호스트 허용
-      "localhost",
+      'host.docker.internal', // Docker 호스트 허용
+      'localhost',
     ],
     port: 5174,
   },


### PR DESCRIPTION
## 이슈 번호

closes #5 

---

## 작업 개요

- 로그인한 보호자의 세션 정보를 통해 userId를 가져와 백엔드 템플릿 리스트 API 호출
- 응답 받은 템플릿 데이터를 리스트 형태로 렌더링
---

## 어떻게 해결했는가?

- 로그인한 보호자의 세션 정보를 통해 userId를 가져와 백엔드 템플릿 리스트 API 호출
- 응답 받은 템플릿 데이터를 리스트 형태로 렌더링

---

## 작업 체크 리스트

- [x] 보호자 세션 정보 확인 후 userId 추출
- [x] `/api/v1/template/guardian/list` 호출
- [x] 템플릿 리스트 map으로 렌더링
- [x] 기존 임시 템플릿 제거
- [x] 템플릿이 비어있는 경우 예외 처리
- [x] 상태(status)에 따라 표시 색상 또는 아이콘 구분 유지

## 관련 이미지 (선택)



## PR전 체크 리스트

- [ ] main / dev 브랜치가 아닌 기능별로 필요한 브랜치에서 작업했다.
- [ ] 충돌을 방지하기 위해 가장 최신 dev 브랜치를 merge 했다.
- [ ] 구현한 기능이 정상적으로 작동하였는지 테스트 했다.
- [ ] 코드에 불필요한 console.log 나 주석이 남아있지 않다.
- [ ] 팀내 컨벤션을 지키며 변수명과 함수명을 명시적으로 작성하였다.

아래 내용작성해주시고 push 한번더하시고 PR올려주세용