### PR TITLE
Feat/setting

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -14,7 +14,7 @@ const BottomNav = () => {
   const tabs = [
     { to: '/notification', icon: <MdNotifications size={24} /> }, // 알림
     { to: '/board', icon: <MdForum size={24} /> }, // 게시판
-    { to: '/add', icon: <MdAddCircle size={32} /> }, // 추가
+    // { to: '/add', icon: <MdAddCircle size={32} /> },
     { to: '/list', icon: <MdAddCircle size={32} /> }, // 추가
     { to: '/diary', icon: <MdCalendarToday size={24} /> }, //캘린더
     { to: '/settings', icon: <MdSettings size={24} /> }, //설정

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -1,23 +1,23 @@
-import { Link, useLocation } from 'react-router-dom';
-import '../styles/BottomNav.css';
+import { Link, useLocation } from "react-router-dom";
+import "../styles/BottomNav.css";
 import {
   MdNotifications,
   MdForum,
   MdAddCircle,
   MdCalendarToday,
   MdSettings,
-} from 'react-icons/md';
+} from "react-icons/md";
 
 const BottomNav = () => {
   const location = useLocation();
 
   const tabs = [
-    { to: '/notification', icon: <MdNotifications size={24} /> }, // 알림
-    { to: '/board', icon: <MdForum size={24} /> }, // 게시판
+    { to: "/notification", icon: <MdNotifications size={24} /> }, // 알림
+    { to: "/board", icon: <MdForum size={24} /> }, // 게시판
     // { to: '/add', icon: <MdAddCircle size={32} /> },
-    { to: '/list', icon: <MdAddCircle size={32} /> }, // 추가
-    { to: '/diary', icon: <MdCalendarToday size={24} /> }, //캘린더
-    { to: '/settings', icon: <MdSettings size={24} /> }, //설정
+    { to: "/list", icon: <MdAddCircle size={32} /> }, // 추가
+    { to: "/diary", icon: <MdCalendarToday size={24} /> }, //캘린더
+    { to: "/settings", icon: <MdSettings size={24} /> }, //설정
   ];
 
   return (
@@ -26,7 +26,7 @@ const BottomNav = () => {
         <Link
           key={tab.to}
           to={tab.to}
-          className={`tab-item ${location.pathname === tab.to ? 'active' : ''}`}
+          className={`tab-item ${location.pathname === tab.to ? "active" : ""}`}
         >
           {tab.icon}
           <span>{tab.label}</span>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,12 @@
-import { useNavigate, useLocation } from 'react-router-dom';
-import { FiPlusCircle, FiArrowLeft } from 'react-icons/fi';
-import '../styles/Header.css';
+import { useNavigate, useLocation } from "react-router-dom";
+import { FiPlusCircle, FiArrowLeft } from "react-icons/fi";
+import "../styles/Header.css";
 
 function Header() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const isDiaryPage = location.pathname.startsWith('/calendar/diary');
+  const isDiaryPage = location.pathname.startsWith("/calendar/diary");
 
   const handleBackClick = () => navigate(-1);
 

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 const Add = () => {
   return <div>메시지 추가</div>;

--- a/src/pages/DiaryCalendar.jsx
+++ b/src/pages/DiaryCalendar.jsx
@@ -11,12 +11,33 @@ function DiaryCalendar() {
   const navigate = useNavigate();
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [activeStartDate, setActiveStartDate] = useState(new Date());
-  const [writtenDiaryMap, setWrittenDiaryMap] = useState({}); // dateKey → status
+  const [writtenDiaryMap, setWrittenDiaryMap] = useState({});
+  const [userId, setUserId] = useState(null);
 
   useEffect(() => {
+    // 1) 세션 유저 확인
     axios
-      .get('http://localhost:8080/api/diaries')
+      .get(`${import.meta.env.VITE_API_URL}/api/v1/auth/check/currentinfo`, {
+        withCredentials: true,
+      })
       .then((res) => {
+        if (res.data?.auth) {
+          const id = res.data.auth.userId;
+          setUserId(id);
+          console.log('✅ 세션 유저 ID:', id);
+
+          // 2) 다이어리 목록 가져오기
+          return axios.get(`${import.meta.env.VITE_API_URL}/api/diaries`, {
+            withCredentials: true,
+          });
+        } else {
+          console.warn('⚠️ 로그인 안 됨');
+          return null;
+        }
+      })
+      .then((res) => {
+        if (!res) return;
+
         const list = Array.isArray(res.data)
           ? res.data
           : Array.isArray(res.data.data)
@@ -26,13 +47,13 @@ function DiaryCalendar() {
         const map = {};
         list.forEach((entry) => {
           const dateKey = formatLocalDate(parseLocalDate(entry.diaryDate));
-          map[dateKey] = entry.status; // "좋음", "보통", "나쁨"
+          map[dateKey] = entry.status;
         });
 
         setWrittenDiaryMap(map);
       })
       .catch((err) => {
-        console.error('다이어리 목록 조회 실패:', err);
+        console.error(' 조회 실패:', err);
       });
   }, []);
 
@@ -40,9 +61,13 @@ function DiaryCalendar() {
     const dateKey = formatLocalDate(selectedDate);
 
     try {
-      const res = await axios.get('http://localhost:8080/api/diaries/check', {
-        params: { date: dateKey },
-      });
+      const res = await axios.get(
+        `${import.meta.env.VITE_API_URL}/api/diaries/check`,
+        {
+          params: { date: dateKey },
+          withCredentials: true,
+        }
+      );
 
       const { mode, diaryId } = res.data;
 
@@ -50,7 +75,7 @@ function DiaryCalendar() {
         state: { selectedDate, mode, diaryId },
       });
     } catch (err) {
-      console.error('다이어리 작성 여부 확인 실패:', err);
+      console.error('다이어리 작성 확인 실패:', err);
     }
   };
 
@@ -60,9 +85,13 @@ function DiaryCalendar() {
 
     if (writtenDiaryMap[dateKey]) {
       try {
-        const res = await axios.get('http://localhost:8080/api/diaries/check', {
-          params: { date: dateKey },
-        });
+        const res = await axios.get(
+          `${import.meta.env.VITE_API_URL}/api/diaries/check`,
+          {
+            params: { date: dateKey },
+            withCredentials: true,
+          }
+        );
         const { diaryId } = res.data;
 
         navigate('/diary/detail', {

--- a/src/pages/DiaryCalendar.jsx
+++ b/src/pages/DiaryCalendar.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
-import Calendar from 'react-calendar';
-import { FaSmile, FaMeh, FaFrown } from 'react-icons/fa';
-import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
-import 'react-calendar/dist/Calendar.css';
-import '../styles/DiaryCalendar.css';
-import { parseLocalDate, formatLocalDate } from '../utils/date';
+import React, { useState, useEffect } from "react";
+import Calendar from "react-calendar";
+import { FaSmile, FaMeh, FaFrown } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import "react-calendar/dist/Calendar.css";
+import "../styles/DiaryCalendar.css";
+import { parseLocalDate, formatLocalDate } from "../utils/date";
 
 function DiaryCalendar() {
   const navigate = useNavigate();
@@ -24,14 +24,14 @@ function DiaryCalendar() {
         if (res.data?.auth) {
           const id = res.data.auth.userId;
           setUserId(id);
-          console.log('✅ 세션 유저 ID:', id);
+          console.log("✅ 세션 유저 ID:", id);
 
           // 2) 다이어리 목록 가져오기
           return axios.get(`${import.meta.env.VITE_API_URL}/api/diaries`, {
             withCredentials: true,
           });
         } else {
-          console.warn('⚠️ 로그인 안 됨');
+          console.warn("⚠️ 로그인 안 됨");
           return null;
         }
       })
@@ -53,7 +53,7 @@ function DiaryCalendar() {
         setWrittenDiaryMap(map);
       })
       .catch((err) => {
-        console.error(' 조회 실패:', err);
+        console.error(" 조회 실패:", err);
       });
   }, []);
 
@@ -71,11 +71,11 @@ function DiaryCalendar() {
 
       const { mode, diaryId } = res.data;
 
-      navigate('/diary/form', {
+      navigate("/diary/form", {
         state: { selectedDate, mode, diaryId },
       });
     } catch (err) {
-      console.error('다이어리 작성 확인 실패:', err);
+      console.error("다이어리 작성 확인 실패:", err);
     }
   };
 
@@ -94,11 +94,11 @@ function DiaryCalendar() {
         );
         const { diaryId } = res.data;
 
-        navigate('/diary/detail', {
+        navigate("/diary/detail", {
           state: { selectedDate: date, diaryId },
         });
       } catch (err) {
-        console.error('상세 페이지 이동 실패:', err);
+        console.error("상세 페이지 이동 실패:", err);
       }
     }
   };
@@ -133,22 +133,22 @@ function DiaryCalendar() {
           showNeighboringMonth={false}
           formatDay={(locale, date) => date.getDate()}
           tileClassName={({ date, view }) => {
-            if (view === 'month') {
+            if (view === "month") {
               const dateKey = formatLocalDate(date);
               const status = writtenDiaryMap[dateKey];
-              if (status === '좋음') return 'status-good';
-              if (status === '보통') return 'status-normal';
-              if (status === '나쁨') return 'status-bad';
+              if (status === "좋음") return "status-good";
+              if (status === "보통") return "status-normal";
+              if (status === "나쁨") return "status-bad";
             }
             return null;
           }}
           tileContent={({ date, view }) => {
-            if (view === 'month') {
+            if (view === "month") {
               const dateKey = formatLocalDate(date);
               const status = writtenDiaryMap[dateKey];
-              if (status === '좋음') return <FaSmile className="emoji good" />;
-              if (status === '보통') return <FaMeh className="emoji normal" />;
-              if (status === '나쁨') return <FaFrown className="emoji bad" />;
+              if (status === "좋음") return <FaSmile className="emoji good" />;
+              if (status === "보통") return <FaMeh className="emoji normal" />;
+              if (status === "나쁨") return <FaFrown className="emoji bad" />;
             }
             return null;
           }}

--- a/src/pages/DiaryDetail.jsx
+++ b/src/pages/DiaryDetail.jsx
@@ -24,19 +24,25 @@ function DiaryDetail() {
   useEffect(() => {
     if (diaryId) {
       axios
-        .get(`http://localhost:8080/api/diaries/${diaryId}`)
+        .get(`http://localhost:8080/api/diaries/${diaryId}`, {
+          withCredentials: true,
+        })
         .then((res) => {
-          const entry = res.data;
+          const entry = res.data.data || res.data;
           setStatus(entry.status || '');
           setContent(entry.textBody || '');
         })
-        .catch((err) => console.error('다이어리 불러오기 실패:', err));
+        .catch((err) => {
+          console.error('다이어리 불러오기 실패:', err);
+        });
     }
   }, [diaryId]);
 
   const handleDelete = () => {
     axios
-      .delete(`http://localhost:8080/api/diaries/${diaryId}`)
+      .delete(`http://localhost:8080/api/diaries/${diaryId}`, {
+        withCredentials: true,
+      })
       .then(() => {
         alert('일지가 삭제되었습니다.');
         navigate('/diary');

--- a/src/pages/DiaryDetail.jsx
+++ b/src/pages/DiaryDetail.jsx
@@ -1,24 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { FiArrowLeft } from 'react-icons/fi';
-import axios from 'axios';
-import '../styles/DiaryDetail.css';
-import { parseLocalDate, formatLocalDate } from '../utils/date';
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { FiArrowLeft } from "react-icons/fi";
+import axios from "axios";
+import "../styles/DiaryDetail.css";
+import { parseLocalDate, formatLocalDate } from "../utils/date";
 
 function DiaryDetail() {
   const location = useLocation();
   const navigate = useNavigate();
 
   const diaryDate = location.state?.selectedDate
-    ? typeof location.state.selectedDate === 'string'
+    ? typeof location.state.selectedDate === "string"
       ? parseLocalDate(location.state.selectedDate)
       : location.state.selectedDate
     : new Date();
 
   const diaryId = location.state?.diaryId || null;
 
-  const [status, setStatus] = useState('');
-  const [content, setContent] = useState('');
+  const [status, setStatus] = useState("");
+  const [content, setContent] = useState("");
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
@@ -29,11 +29,11 @@ function DiaryDetail() {
         })
         .then((res) => {
           const entry = res.data.data || res.data;
-          setStatus(entry.status || '');
-          setContent(entry.textBody || '');
+          setStatus(entry.status || "");
+          setContent(entry.textBody || "");
         })
         .catch((err) => {
-          console.error('다이어리 불러오기 실패:', err);
+          console.error("다이어리 불러오기 실패:", err);
         });
     }
   }, [diaryId]);
@@ -44,17 +44,17 @@ function DiaryDetail() {
         withCredentials: true,
       })
       .then(() => {
-        alert('일지가 삭제되었습니다.');
-        navigate('/diary');
+        alert("일지가 삭제되었습니다.");
+        navigate("/diary");
       })
-      .catch((err) => console.error('일지 삭제 실패:', err));
+      .catch((err) => console.error("일지 삭제 실패:", err));
   };
 
   return (
     <div className="diary-detail-wrapper">
       {/* 헤더 */}
       <div className="detail-header">
-        <button className="back-button" onClick={() => navigate('/diary')}>
+        <button className="back-button" onClick={() => navigate("/diary")}>
           <FiArrowLeft />
         </button>
         <div className="diary-detail-date">{formatLocalDate(diaryDate)}</div>
@@ -64,7 +64,7 @@ function DiaryDetail() {
       <main className="detail-wrapper">
         <div
           className={`diary-detail-status ${
-            status === '좋음' ? 'good' : status === '보통' ? 'normal' : 'bad'
+            status === "좋음" ? "good" : status === "보통" ? "normal" : "bad"
           }`}
         >
           {status}
@@ -76,8 +76,8 @@ function DiaryDetail() {
           <button
             className="btn-edit"
             onClick={() =>
-              navigate('/diary/form', {
-                state: { selectedDate: diaryDate, mode: 'edit', diaryId },
+              navigate("/diary/form", {
+                state: { selectedDate: diaryDate, mode: "edit", diaryId },
               })
             }
           >
@@ -85,32 +85,17 @@ function DiaryDetail() {
           </button>
           <button
             className="btn-delete"
-            onClick={() => setShowDeleteConfirm(true)}
+            onClick={() => {
+              const confirmDelete = window.confirm("정말 삭제하시겠습니까?");
+              if (confirmDelete) {
+                handleDelete();
+              }
+            }}
           >
             삭제
           </button>
         </div>
       </main>
-
-      {/* 모달 */}
-      {showDeleteConfirm && (
-        <div className="modal-backdrop">
-          <div className="modal">
-            <p>정말 삭제하시겠습니까?</p>
-            <div className="modal-buttons">
-              <button className="btn-yes" onClick={handleDelete}>
-                예
-              </button>
-              <button
-                className="btn-no"
-                onClick={() => setShowDeleteConfirm(false)}
-              >
-                아니오
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/pages/DiaryForm.jsx
+++ b/src/pages/DiaryForm.jsx
@@ -28,9 +28,12 @@ function DiaryForm() {
   useEffect(() => {
     if (mode === 'edit' && diaryId) {
       axios
-        .get(`http://localhost:8080/api/diaries/${diaryId}`)
+        .get(`${import.meta.env.VITE_API_URL}/api/diaries/${diaryId}`, {
+          withCredentials: true,
+        })
         .then((res) => {
           const entry = res.data;
+
           setStatus(entry.status || '');
           setContent(entry.textBody || '');
           setInitialStatus(entry.status || '');
@@ -47,31 +50,64 @@ function DiaryForm() {
       status,
       textBody: content,
     };
-
+    console.log('📤 수정 payload:', payload);
     if (mode === 'edit') {
       axios
-        .put(`http://localhost:8080/api/diaries/${diaryId}`, payload)
+        .put(
+          `${import.meta.env.VITE_API_URL}/api/diaries/${diaryId}`,
+          payload,
+          {
+            withCredentials: true,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        )
+
         .then(() => {
           alert('일지가 수정되었습니다.');
           navigate('/diary/detail', {
             state: { selectedDate: diaryDate, diaryId },
           });
         })
-        .catch(() => alert('수정 실패'));
+        .catch((err) => {
+          console.error('수정 실패:', err);
+          alert('수정 실패');
+        });
     } else {
       axios
-        .post('http://localhost:8080/api/diaries', payload)
+        .post(`${import.meta.env.VITE_API_URL}/api/diaries`, payload, {
+          withCredentials: true,
+        })
         .then(() => {
           alert('일지가 저장되었습니다.');
           navigate('/diary');
         })
-        .catch(() => alert('저장 실패'));
+        .catch((err) => {
+          console.error('저장 실패:', err);
+          alert('저장 실패');
+        });
     }
   };
 
   const handleCancel = () => {
     setStatus(initialStatus);
     setContent(initialContent);
+  };
+
+  // 삭제 핸들러
+  const handleDelete = () => {
+    if (!diaryId) return;
+
+    axios
+      .delete(`${import.meta.env.VITE_API_URL}/api/diaries/${diaryId}`, {
+        withCredentials: true,
+      })
+      .then(() => {
+        alert('일지가 삭제되었습니다.');
+        navigate('/diary');
+      })
+      .catch((err) => console.error('삭제 실패:', err));
   };
 
   return (

--- a/src/pages/DiaryForm.jsx
+++ b/src/pages/DiaryForm.jsx
@@ -1,32 +1,32 @@
-import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { FiArrowLeft } from 'react-icons/fi';
-import axios from 'axios';
-import '../styles/DiaryForm.css';
-import { parseLocalDate, formatLocalDate } from '../utils/date';
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { FiArrowLeft } from "react-icons/fi";
+import axios from "axios";
+import "../styles/DiaryForm.css";
+import { parseLocalDate, formatLocalDate } from "../utils/date";
 
 function DiaryForm() {
   const location = useLocation();
   const navigate = useNavigate();
 
   const diaryDate = location.state?.selectedDate
-    ? typeof location.state.selectedDate === 'string'
+    ? typeof location.state.selectedDate === "string"
       ? parseLocalDate(location.state.selectedDate)
       : location.state.selectedDate
     : new Date();
 
-  const mode = location.state?.mode || 'create';
+  const mode = location.state?.mode || "create";
   const diaryId = location.state?.diaryId || null;
 
-  const STATUS_OPTIONS = ['좋음', '보통', '나쁨'];
-  const [status, setStatus] = useState('');
-  const [content, setContent] = useState('');
-  const [initialStatus, setInitialStatus] = useState('');
-  const [initialContent, setInitialContent] = useState('');
+  const STATUS_OPTIONS = ["좋음", "보통", "나쁨"];
+  const [status, setStatus] = useState("");
+  const [content, setContent] = useState("");
+  const [initialStatus, setInitialStatus] = useState("");
+  const [initialContent, setInitialContent] = useState("");
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
-    if (mode === 'edit' && diaryId) {
+    if (mode === "edit" && diaryId) {
       axios
         .get(`${import.meta.env.VITE_API_URL}/api/diaries/${diaryId}`, {
           withCredentials: true,
@@ -34,12 +34,12 @@ function DiaryForm() {
         .then((res) => {
           const entry = res.data;
 
-          setStatus(entry.status || '');
-          setContent(entry.textBody || '');
-          setInitialStatus(entry.status || '');
-          setInitialContent(entry.textBody || '');
+          setStatus(entry.status || "");
+          setContent(entry.textBody || "");
+          setInitialStatus(entry.status || "");
+          setInitialContent(entry.textBody || "");
         })
-        .catch((err) => console.error('일지 불러오기 실패:', err));
+        .catch((err) => console.error("일지 불러오기 실패:", err));
     }
   }, [mode, diaryId]);
 
@@ -50,8 +50,8 @@ function DiaryForm() {
       status,
       textBody: content,
     };
-    console.log('📤 수정 payload:', payload);
-    if (mode === 'edit') {
+    console.log("📤 수정 payload:", payload);
+    if (mode === "edit") {
       axios
         .put(
           `${import.meta.env.VITE_API_URL}/api/diaries/${diaryId}`,
@@ -59,20 +59,20 @@ function DiaryForm() {
           {
             withCredentials: true,
             headers: {
-              'Content-Type': 'application/json',
+              "Content-Type": "application/json",
             },
           }
         )
 
         .then(() => {
-          alert('일지가 수정되었습니다.');
-          navigate('/diary/detail', {
+          alert("일지가 수정되었습니다.");
+          navigate("/diary/detail", {
             state: { selectedDate: diaryDate, diaryId },
           });
         })
         .catch((err) => {
-          console.error('수정 실패:', err);
-          alert('수정 실패');
+          console.error("수정 실패:", err);
+          alert("수정 실패");
         });
     } else {
       axios
@@ -80,12 +80,12 @@ function DiaryForm() {
           withCredentials: true,
         })
         .then(() => {
-          alert('일지가 저장되었습니다.');
-          navigate('/diary');
+          alert("일지가 저장되었습니다.");
+          navigate("/diary");
         })
         .catch((err) => {
-          console.error('저장 실패:', err);
-          alert('저장 실패');
+          console.error("저장 실패:", err);
+          alert("저장 실패");
         });
     }
   };
@@ -104,17 +104,17 @@ function DiaryForm() {
         withCredentials: true,
       })
       .then(() => {
-        alert('일지가 삭제되었습니다.');
-        navigate('/diary');
+        alert("일지가 삭제되었습니다.");
+        navigate("/diary");
       })
-      .catch((err) => console.error('삭제 실패:', err));
+      .catch((err) => console.error("삭제 실패:", err));
   };
 
   return (
     <div className="diary-form-wrapper">
       {/* 헤더 */}
       <div className="form-header">
-        <button className="back-button" onClick={() => navigate('/diary')}>
+        <button className="back-button" onClick={() => navigate("/diary")}>
           <FiArrowLeft />
         </button>
         <div className="diary-date">{formatLocalDate(diaryDate)}</div>
@@ -126,11 +126,11 @@ function DiaryForm() {
         <div className="status-options">
           {STATUS_OPTIONS.map((label) => {
             const badgeClass =
-              label === '좋음'
-                ? 'good'
-                : label === '보통'
-                ? 'normal'
-                : 'danger';
+              label === "좋음"
+                ? "good"
+                : label === "보통"
+                ? "normal"
+                : "danger";
             return (
               <label key={label} className="status-option">
                 <input
@@ -155,9 +155,9 @@ function DiaryForm() {
 
         <div className="form-buttons">
           <button className="btn-save" onClick={handleSave}>
-            {mode === 'edit' ? '수정 완료' : '등록'}
+            {mode === "edit" ? "수정 완료" : "등록"}
           </button>
-          {mode === 'edit' && (
+          {mode === "edit" && (
             <button className="btn-cancel" onClick={handleCancel}>
               취소
             </button>

--- a/src/pages/DiaryMain.jsx
+++ b/src/pages/DiaryMain.jsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import { Outlet } from 'react-router-dom';
-import Header from '../components/Header';
+import { useState } from "react";
+import { Outlet } from "react-router-dom";
+import Header from "../components/Header";
 
 function DiaryMain() {
   const [selectedDate, setSelectedDate] = useState(new Date());

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,6 +1,6 @@
-import { Outlet } from 'react-router-dom';
-import Header from '../components/Header';
-import BottomNav from '../components/BottomNav';
+import { Outlet } from "react-router-dom";
+import Header from "../components/Header";
+import BottomNav from "../components/BottomNav";
 
 const Layout = () => {
   return (

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import '../styles/login.css';
-import imageSrc from '../assets/image.png';
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from "react";
+import "../styles/login.css";
+import imageSrc from "../assets/image.png";
+import { useNavigate } from "react-router-dom";
 
 const Login = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -59,16 +59,16 @@ const Login = () => {
           <button
             onClick={handleKakaoLogin}
             disabled={isLoading || loginSuccess}
-            className={`kakao-login-btn ${isLoading ? 'loading' : ''} ${
-              loginSuccess ? 'success' : ''
+            className={`kakao-login-btn ${isLoading ? "loading" : ""} ${
+              loginSuccess ? "success" : ""
             }`}
           >
             <img className="kakao-icon" src={imageSrc} />
             {loginSuccess
-              ? '로그인 성공!'
+              ? "로그인 성공!"
               : isLoading
-              ? '카카오 로그인 중...'
-              : '카카오로 간편 시작하기'}
+              ? "카카오 로그인 중..."
+              : "카카오로 간편 시작하기"}
           </button>
 
           <div className="divider">
@@ -82,10 +82,10 @@ const Login = () => {
           </div>
 
           <div className="privacy-notice">
-            계속 진행하시면{' '}
+            계속 진행하시면{" "}
             <a href="#" onClick={(e) => e.preventDefault()}>
               서비스 이용약관
-            </a>{' '}
+            </a>{" "}
             및<br />
             <a href="#" onClick={(e) => e.preventDefault()}>
               개인정보처리방침

--- a/src/pages/MessageAddForm.jsx
+++ b/src/pages/MessageAddForm.jsx
@@ -1,13 +1,13 @@
-import { useState } from 'react';
-import '../styles/messageAddForm.css';
-import axios from 'axios';
-import { useNavigate } from 'react-router-dom';
+import { useState } from "react";
+import "../styles/messageAddForm.css";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
 
 const MessageAddForm = () => {
   const [formData, setFormData] = useState({
-    urgency: '',
+    urgency: "",
     repeatInterval: 300,
-    content: '',
+    content: "",
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
@@ -15,27 +15,27 @@ const MessageAddForm = () => {
   // 긴급도 태그 옵션
   const urgencyTypes = [
     {
-      id: 'emergency',
-      label: '긴급',
-      color: '#FF4444',
-      bgColor: '#FFE6E6',
-      description: '즉시 확인이 필요한 중요한 메세지',
+      id: "emergency",
+      label: "긴급",
+      color: "#FF4444",
+      bgColor: "#FFE6E6",
+      description: "즉시 확인이 필요한 중요한 메세지",
       defaultInterval: 30,
     },
     {
-      id: 'normal',
-      label: '보통',
-      color: '#FF8C00',
-      bgColor: '#FFF3E6',
-      description: '일반적인 알림 메세지',
+      id: "normal",
+      label: "보통",
+      color: "#FF8C00",
+      bgColor: "#FFF3E6",
+      description: "일반적인 알림 메세지",
       defaultInterval: 180,
     },
     {
-      id: 'good',
-      label: '양호',
-      color: '#4CAF50',
-      bgColor: '#E8F5E8',
-      description: '격려와 안부를 위한 메세지',
+      id: "good",
+      label: "양호",
+      color: "#4CAF50",
+      bgColor: "#E8F5E8",
+      description: "격려와 안부를 위한 메세지",
       defaultInterval: 300,
     },
   ];
@@ -68,12 +68,12 @@ const MessageAddForm = () => {
 
   const handleSubmit = async () => {
     if (!formData.urgency) {
-      alert('긴급도를 선택해주세요.');
+      alert("긴급도를 선택해주세요.");
       return;
     }
 
     if (!formData.content.trim()) {
-      alert('메세지 내용을 입력해주세요.');
+      alert("메세지 내용을 입력해주세요.");
       return;
     }
 
@@ -82,9 +82,9 @@ const MessageAddForm = () => {
     try {
       // 긴급도 태그 옵션 → 백엔드 status 값으로 매핑
       const urgencyMap = {
-        emergency: 'HIGH',
-        normal: 'MEDIUM',
-        good: 'LOW',
+        emergency: "HIGH",
+        normal: "MEDIUM",
+        good: "LOW",
       };
 
       const payload = {
@@ -100,10 +100,10 @@ const MessageAddForm = () => {
         { withCredentials: true }
       );
 
-      alert('메세지가 성공적으로 추가되었습니다!');
-      navigate('/list');
+      alert("메세지가 성공적으로 추가되었습니다!");
+      navigate("/list");
     } catch (error) {
-      alert('메세지 추가에 실패했습니다. 다시 시도해주세요.');
+      alert("메세지 추가에 실패했습니다. 다시 시도해주세요.");
     } finally {
       setIsSubmitting(false);
     }
@@ -133,7 +133,7 @@ const MessageAddForm = () => {
               <div
                 key={type.id}
                 className={`urgency-tag ${type.id} ${
-                  formData.urgency === type.id ? 'selected' : ''
+                  formData.urgency === type.id ? "selected" : ""
                 }`}
                 onClick={() => handleUrgencySelect(type.id)}
               >
@@ -211,7 +211,7 @@ const MessageAddForm = () => {
           {selectedType && (
             <div className="template-suggestions">
               <div className="template-title">💡 추천 템플릿</div>
-              {selectedType.id === 'emergency' && (
+              {selectedType.id === "emergency" && (
                 <>
                   <div
                     className="template-item"
@@ -219,7 +219,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          '🚨 즉시 확인이 필요합니다. 안전을 위해 연락주세요!',
+                          "🚨 즉시 확인이 필요합니다. 안전을 위해 연락주세요!",
                       })
                     }
                   >
@@ -230,7 +230,7 @@ const MessageAddForm = () => {
                     onClick={() =>
                       setFormData({
                         ...formData,
-                        content: '⚠️ 긴급 상황입니다. 즉시 대응해주세요.',
+                        content: "⚠️ 긴급 상황입니다. 즉시 대응해주세요.",
                       })
                     }
                   >
@@ -238,14 +238,14 @@ const MessageAddForm = () => {
                   </div>
                 </>
               )}
-              {selectedType.id === 'normal' && (
+              {selectedType.id === "normal" && (
                 <>
                   <div
                     className="template-item"
                     onClick={() =>
                       setFormData({
                         ...formData,
-                        content: '💊 약 복용 시간입니다. 물과 함께 드세요.',
+                        content: "💊 약 복용 시간입니다. 물과 함께 드세요.",
                       })
                     }
                   >
@@ -257,7 +257,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          '🏥 건강 체크 시간이에요. 혈압을 측정해주세요.',
+                          "🏥 건강 체크 시간이에요. 혈압을 측정해주세요.",
                       })
                     }
                   >
@@ -265,7 +265,7 @@ const MessageAddForm = () => {
                   </div>
                 </>
               )}
-              {selectedType.id === 'good' && (
+              {selectedType.id === "good" && (
                 <>
                   <div
                     className="template-item"
@@ -273,7 +273,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          '😊 오늘 하루도 건강하게 보내세요! 항상 응원하고 있어요.',
+                          "😊 오늘 하루도 건강하게 보내세요! 항상 응원하고 있어요.",
                       })
                     }
                   >
@@ -285,7 +285,7 @@ const MessageAddForm = () => {
                       setFormData({
                         ...formData,
                         content:
-                          '💝 컨디션이 좋아 보여서 기뻐요. 계속 잘 지내세요!',
+                          "💝 컨디션이 좋아 보여서 기뻐요. 계속 잘 지내세요!",
                       })
                     }
                   >
@@ -300,7 +300,7 @@ const MessageAddForm = () => {
               <div className="preview-title">📱 환자 화면 미리보기</div>
               <div className="preview-message">{formData.content}</div>
               <div className="preview-meta">
-                {selectedType?.label} • {formatTime(formData.repeatInterval)}{' '}
+                {selectedType?.label} • {formatTime(formData.repeatInterval)}{" "}
                 반복
               </div>
             </div>
@@ -314,7 +314,7 @@ const MessageAddForm = () => {
             isSubmitting || !formData.urgency || !formData.content.trim()
           }
         >
-          {isSubmitting ? '메세지 추가 중...' : '메세지 추가 완료'}
+          {isSubmitting ? "메세지 추가 중..." : "메세지 추가 완료"}
         </button>
       </div>
     </div>

--- a/src/pages/MessageList.jsx
+++ b/src/pages/MessageList.jsx
@@ -11,6 +11,7 @@ const MessageList = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    console.log(import.meta.env.VITE_API_URL);
     axios
       .get(`${import.meta.env.VITE_API_URL}/dev/session/getUserInfo`, {
         withCredentials: true,

--- a/src/pages/MessageList.jsx
+++ b/src/pages/MessageList.jsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
-import '../styles/messageList.css';
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import "../styles/messageList.css";
 
 const MessageList = () => {
   const [messages, setMessages] = useState([]);
   const [selectedItems, setSelectedItems] = useState(new Set());
   const [activeItemId, setActiveItemId] = useState(null);
-  const [editingContent, setEditingContent] = useState('');
+  const [editingContent, setEditingContent] = useState("");
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -32,7 +32,7 @@ const MessageList = () => {
         setMessages(mapped);
       })
       .catch((err) => {
-        console.error('메시지 불러오기 실패', err);
+        console.error("메시지 불러오기 실패", err);
       });
   }, []);
 
@@ -69,7 +69,7 @@ const MessageList = () => {
       }
       setMessages(messages.filter((m) => !selectedItems.has(m.id)));
       setSelectedItems(new Set());
-      alert('선택된 메시지가 삭제되었습니다.');
+      alert("선택된 메시지가 삭제되었습니다.");
     } catch (err) {
       console.error(err);
     }
@@ -77,7 +77,7 @@ const MessageList = () => {
 
   /** 단일 삭제 */
   const handleDeleteItem = async (id) => {
-    if (!confirm('삭제할까요?')) return;
+    if (!confirm("삭제할까요?")) return;
 
     try {
       await axios.delete(
@@ -108,7 +108,7 @@ const MessageList = () => {
   /** 수정 저장 (PUT 요청) */
   const handleEditSave = async (id) => {
     if (!editingContent.trim()) {
-      alert('내용 입력 필요!');
+      alert("내용 입력 필요!");
       return;
     }
 
@@ -132,7 +132,7 @@ const MessageList = () => {
             : m
         )
       );
-      setEditingContent('');
+      setEditingContent("");
     } catch (err) {
       console.error(err);
     }
@@ -143,7 +143,7 @@ const MessageList = () => {
     setMessages(
       messages.map((m) => (m.id === id ? { ...m, isEditing: false } : m))
     );
-    setEditingContent('');
+    setEditingContent("");
   };
 
   const isAllSelected =
@@ -155,7 +155,7 @@ const MessageList = () => {
       <div className="header-section">
         <div className="header-content">
           <h1 className="page-title">메세지 관리</h1>
-          <button className="add-btn" onClick={() => navigate('/add')}>
+          <button className="add-btn" onClick={() => navigate("/add")}>
             + 메세지 추가
           </button>
         </div>
@@ -173,7 +173,7 @@ const MessageList = () => {
             </label>
 
             <button
-              className={`delete-selected-btn ${hasSelection ? 'active' : ''}`}
+              className={`delete-selected-btn ${hasSelection ? "active" : ""}`}
               onClick={handleDeleteSelected}
               disabled={!hasSelection}
             >
@@ -216,8 +216,8 @@ const MessageList = () => {
                       onChange={(e) => setEditingContent(e.target.value)}
                       autoFocus
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter') handleEditSave(message.id);
-                        if (e.key === 'Escape') handleEditCancel(message.id);
+                        if (e.key === "Enter") handleEditSave(message.id);
+                        if (e.key === "Escape") handleEditCancel(message.id);
                       }}
                     />
                     <div className="edit-actions">
@@ -250,7 +250,7 @@ const MessageList = () => {
 
                     <div
                       className={`item-actions ${
-                        activeItemId === message.id ? 'active' : ''
+                        activeItemId === message.id ? "active" : ""
                       }`}
                     >
                       <button

--- a/src/pages/MessageList.jsx
+++ b/src/pages/MessageList.jsx
@@ -11,7 +11,6 @@ const MessageList = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    console.log(import.meta.env.VITE_API_URL);
     axios
       .get(`${import.meta.env.VITE_API_URL}/dev/session/getUserInfo`, {
         withCredentials: true,

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
-import axios from 'axios';
-import '../styles/Settings.css';
-import { parseLocalDate, formatLocalDate } from '../utils/date';
+import { useEffect, useState } from "react";
+import axios from "axios";
+import "../styles/Settings.css";
+import { parseLocalDate, formatLocalDate } from "../utils/date";
 
 function Settings() {
   const [guardian, setGuardian] = useState(null);
@@ -12,14 +12,14 @@ function Settings() {
   const [formData, setFormData] = useState({});
 
   const formatPhone = (value) => {
-    if (!value) return '';
-    value = value.replace(/[^0-9]/g, ''); // 숫자만 남김
+    if (!value) return "";
+    value = value.replace(/[^0-9]/g, ""); // 숫자만 남김
     if (value.length <= 3) {
       return value;
     } else if (value.length <= 7) {
-      return value.replace(/(\d{3})(\d{1,4})/, '$1-$2');
+      return value.replace(/(\d{3})(\d{1,4})/, "$1-$2");
     } else {
-      return value.replace(/(\d{3})(\d{4})(\d{0,4})/, '$1-$2-$3');
+      return value.replace(/(\d{3})(\d{4})(\d{0,4})/, "$1-$2-$3");
     }
   };
 
@@ -30,14 +30,14 @@ function Settings() {
         withCredentials: true,
       })
       .then((res) => {
-        console.log('세션 정보:', res.data);
+        console.log("세션 정보:", res.data);
         setGuardian(res.data.data?.guardian || null);
         setPatient(res.data.data?.patient || null);
-        console.log('guardian:', res.data.data?.guardian);
-        console.log('patient:', res.data.data?.patient);
+        console.log("guardian:", res.data.data?.guardian);
+        console.log("patient:", res.data.data?.patient);
       })
       .catch((err) => {
-        console.error('유저 정보 불러오기 실패:', err);
+        console.error("유저 정보 불러오기 실패:", err);
       })
       .finally(() => {
         setLoading(false);
@@ -45,14 +45,14 @@ function Settings() {
   }, []);
 
   useEffect(() => {
-    if (guardian && editMode === 'guardian') {
+    if (guardian && editMode === "guardian") {
       setFormData({
-        name: guardian.name || '',
-        phone: formatPhone(guardian.phone || ''),
-        profileImageUrl: guardian.profileImageUrl || '',
+        name: guardian.name || "",
+        phone: formatPhone(guardian.phone || ""),
+        profileImageUrl: guardian.profileImageUrl || "",
         guardianBirth: guardian.guardianBirth
           ? formatLocalDate(parseLocalDate(guardian.guardianBirth))
-          : '',
+          : "",
         syncPatientLoginId: guardian.syncPatientLoginId || false,
       });
     }
@@ -66,18 +66,18 @@ function Settings() {
         null,
         { withCredentials: true }
       );
-      alert('로그아웃 되었습니다.');
-      window.location.href = '/';
+      alert("로그아웃 되었습니다.");
+      window.location.href = "/";
     } catch (err) {
-      console.error('로그아웃 실패:', err);
-      alert('로그아웃에 실패했습니다.');
+      console.error("로그아웃 실패:", err);
+      alert("로그아웃에 실패했습니다.");
     }
   };
 
   // 회원 탈퇴
 
   const handleDeleteAccount = async () => {
-    const confirmed = window.confirm('정말 회원 탈퇴하시겠습니까?');
+    const confirmed = window.confirm("정말 회원 탈퇴하시겠습니까?");
     if (!confirmed) return;
 
     try {
@@ -85,11 +85,11 @@ function Settings() {
         `${import.meta.env.VITE_API_URL}/api/v1/auth/guardian`,
         { withCredentials: true }
       );
-      alert('회원 탈퇴 완료');
-      window.location.href = '/';
+      alert("회원 탈퇴 완료");
+      window.location.href = "/";
     } catch (err) {
       alert(
-        '회원 탈퇴 실패: ' + (err.response?.data?.message || '알 수 없는 오류')
+        "회원 탈퇴 실패: " + (err.response?.data?.message || "알 수 없는 오류")
       );
       console.error(err);
     }
@@ -99,25 +99,25 @@ function Settings() {
   const openEditModal = (type) => {
     setEditMode(type);
 
-    if (type === 'guardian' && guardian) {
+    if (type === "guardian" && guardian) {
       setFormData({
-        name: guardian.name || '',
-        phone: formatPhone(guardian.phone || ''),
-        profileImageUrl: guardian.profileImageUrl || '',
+        name: guardian.name || "",
+        phone: formatPhone(guardian.phone || ""),
+        profileImageUrl: guardian.profileImageUrl || "",
         guardianBirth: guardian.guardianBirth
           ? formatLocalDate(parseLocalDate(guardian.guardianBirth))
-          : '',
+          : "",
         syncPatientLoginId: guardian.syncPatientLoginId || false,
       });
     }
-    if (type === 'patient' && patient) {
+    if (type === "patient" && patient) {
       setFormData({
-        name: patient.name || '',
+        name: patient.name || "",
         patientBirth: patient.patientBirth
           ? formatLocalDate(parseLocalDate(patient.patientBirth))
-          : '',
-        newPassword1: '',
-        newPassword2: '',
+          : "",
+        newPassword1: "",
+        newPassword2: "",
       });
     }
   };
@@ -127,7 +127,7 @@ function Settings() {
     const { name, value, type, checked } = e.target;
     setFormData((prev) => ({
       ...prev,
-      [name]: type === 'checkbox' ? checked : value,
+      [name]: type === "checkbox" ? checked : value,
     }));
   };
 
@@ -137,36 +137,36 @@ function Settings() {
       let payload = { ...formData };
 
       // 날짜는 항상 YYYY-MM-DD 형식으로 변환
-      if (editMode === 'guardian' && formData.guardianBirth) {
+      if (editMode === "guardian" && formData.guardianBirth) {
         payload.guardianBirth = formatLocalDate(
           parseLocalDate(formData.guardianBirth)
         );
       }
-      if (editMode === 'patient' && formData.patientBirth) {
+      if (editMode === "patient" && formData.patientBirth) {
         payload.patientBirth = formatLocalDate(
           parseLocalDate(formData.patientBirth)
         );
       }
 
-      if (editMode === 'guardian') {
+      if (editMode === "guardian") {
         await axios.put(
           `${import.meta.env.VITE_API_URL}/api/v1/auth/guardian`,
           payload,
           { withCredentials: true }
         );
-        alert('보호자 정보가 수정되었습니다.');
-      } else if (editMode === 'patient') {
+        alert("보호자 정보가 수정되었습니다.");
+      } else if (editMode === "patient") {
         await axios.put(
           `${import.meta.env.VITE_API_URL}/api/v1/auth/patientinfo`,
           payload,
           { withCredentials: true }
         );
-        alert('환자 정보가 수정되었습니다.');
+        alert("환자 정보가 수정되었습니다.");
       }
       setEditMode(null);
       window.location.reload(); // 수정 후 새로고침
     } catch (err) {
-      alert('수정 실패: ' + (err.response?.data?.message || '알 수 없는 오류'));
+      alert("수정 실패: " + (err.response?.data?.message || "알 수 없는 오류"));
       console.error(err);
     }
   };
@@ -195,7 +195,7 @@ function Settings() {
             <div className="profile-img-placeholder" aria-hidden="true"></div>
           )}
           <div className="profile-name">
-            {guardian?.name ? `${guardian.name}님` : '이름 없음'}
+            {guardian?.name ? `${guardian.name}님` : "이름 없음"}
           </div>
         </div>
 
@@ -204,7 +204,7 @@ function Settings() {
             <div className="label">보호자 프로필 수정</div>
             <button
               className="action-btn"
-              onClick={() => openEditModal('guardian')}
+              onClick={() => openEditModal("guardian")}
             >
               ➔
             </button>
@@ -214,7 +214,7 @@ function Settings() {
             <div className="label">환자 프로필 수정</div>
             <button
               className="action-btn"
-              onClick={() => openEditModal('patient')}
+              onClick={() => openEditModal("patient")}
             >
               ➔
             </button>
@@ -240,12 +240,12 @@ function Settings() {
       {editMode && (
         <div className="modal">
           <div className="modal-content">
-            {console.log('✅ 렌더링 시 formData.phone:', formData.phone)}
+            {console.log("✅ 렌더링 시 formData.phone:", formData.phone)}
             <h3>
-              {editMode === 'guardian' ? '보호자 정보 수정' : '환자 정보 수정'}
+              {editMode === "guardian" ? "보호자 정보 수정" : "환자 정보 수정"}
             </h3>
             <form>
-              {editMode === 'guardian' && (
+              {editMode === "guardian" && (
                 <>
                   <input
                     type="text"
@@ -259,13 +259,12 @@ function Settings() {
                     type="text"
                     name="phone"
                     placeholder="전화번호"
-                    value={formData.phone || formatPhone(guardian?.phone) || ''}
+                    value={formData.phone || formatPhone(guardian?.phone) || ""}
                     onChange={(e) => {
                       const value = formatPhone(e.target.value);
                       setFormData((prev) => ({ ...prev, phone: value }));
                     }}
                   />
-
                   {/* <input
                     type="date"
                     name="guardianBirth"
@@ -283,7 +282,7 @@ function Settings() {
                   </label> */}
                 </>
               )}
-              {editMode === 'patient' && (
+              {editMode === "patient" && (
                 <>
                   <input
                     type="text"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -266,12 +266,12 @@ function Settings() {
                     }}
                   />
 
-                  <input
+                  {/* <input
                     type="date"
                     name="guardianBirth"
                     value={formData.guardianBirth || ''}
                     onChange={handleChange}
-                  />
+                  /> */}
                   {/* <label>
                     환자 로그인 ID 동기화
                     <input
@@ -292,12 +292,12 @@ function Settings() {
                     value={formData.name}
                     onChange={handleChange}
                   />
-                  <input
+                  {/* <input
                     type="date"
                     name="patientBirth"
                     value={formData.patientBirth || ''}
                     onChange={handleChange}
-                  />
+                  /> */}
                   <input
                     type="password"
                     name="newPassword1"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import "../styles/Settings.css";
 import { parseLocalDate, formatLocalDate } from "../utils/date";
+import Login from "./Login";
 
 function Settings() {
   const [guardian, setGuardian] = useState(null);
@@ -112,6 +113,7 @@ function Settings() {
     }
     if (type === "patient" && patient) {
       setFormData({
+        loginId: patient.loginId || "",
         name: patient.name || "",
         patientBirth: patient.patientBirth
           ? formatLocalDate(parseLocalDate(patient.patientBirth))
@@ -200,6 +202,7 @@ function Settings() {
         </div>
 
         <div className="settings-section">
+          {/* 보호자 수정 */}
           <div className="settings-item">
             <div className="label">보호자 프로필 수정</div>
             <button
@@ -210,6 +213,38 @@ function Settings() {
             </button>
           </div>
 
+          {editMode === "guardian" && (
+            <div className="dropdown-edit show">
+              <label htmlFor="guardian-name">이름</label>
+              <input
+                type="text"
+                id="guardian-name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                readOnly
+              />
+
+              <label htmlFor="guardian-phone">전화번호</label>
+              <input
+                type="text"
+                id="guardian-phone"
+                name="phone"
+                value={formData.phone || ""}
+                onChange={(e) => {
+                  const value = formatPhone(e.target.value);
+                  setFormData((prev) => ({ ...prev, phone: value }));
+                }}
+              />
+
+              <div className="dropdown-actions">
+                <button onClick={handleSave}>수정</button>
+                <button onClick={() => setEditMode(null)}>취소</button>
+              </div>
+            </div>
+          )}
+
+          {/* 환자 수정 */}
           <div className="settings-item">
             <div className="label">환자 프로필 수정</div>
             <button
@@ -219,7 +254,52 @@ function Settings() {
               ➔
             </button>
           </div>
+          {editMode === "patient" && (
+            <div className="dropdown-edit show">
+              <label htmlFor="loginId">아이디</label>
+              <input
+                type="text"
+                id="loginId"
+                name="loginId"
+                value={formData.loginId}
+                readOnly
+              />
 
+              <label htmlFor="name">이름</label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+              />
+
+              <label htmlFor="newPassword1">새 비밀번호</label>
+              <input
+                type="password"
+                id="newPassword1"
+                name="newPassword1"
+                value={formData.newPassword1}
+                onChange={handleChange}
+              />
+
+              <label htmlFor="newPassword2">새 비밀번호 확인</label>
+              <input
+                type="password"
+                id="newPassword2"
+                name="newPassword2"
+                value={formData.newPassword2}
+                onChange={handleChange}
+              />
+
+              <div className="dropdown-actions">
+                <button onClick={handleSave}>수정</button>
+                <button onClick={() => setEditMode(null)}>취소</button>
+              </div>
+            </div>
+          )}
+
+          {/* 로그아웃 */}
           <div className="settings-item">
             <div className="label">로그아웃</div>
             <button className="action-btn" onClick={handleLogout}>
@@ -227,6 +307,7 @@ function Settings() {
             </button>
           </div>
 
+          {/* 회원탈퇴 */}
           <div className="settings-item">
             <div className="label">회원탈퇴</div>
             <button className="action-btn" onClick={handleDeleteAccount}>
@@ -235,96 +316,6 @@ function Settings() {
           </div>
         </div>
       </div>
-
-      {/* 모달 */}
-      {editMode && (
-        <div className="modal">
-          <div className="modal-content">
-            {console.log("✅ 렌더링 시 formData.phone:", formData.phone)}
-            <h3>
-              {editMode === "guardian" ? "보호자 정보 수정" : "환자 정보 수정"}
-            </h3>
-            <form>
-              {editMode === "guardian" && (
-                <>
-                  <input
-                    type="text"
-                    name="name"
-                    placeholder="이름"
-                    value={formData.name}
-                    onChange={handleChange}
-                    readOnly
-                  />
-                  <input
-                    type="text"
-                    name="phone"
-                    placeholder="전화번호"
-                    value={formData.phone || formatPhone(guardian?.phone) || ""}
-                    onChange={(e) => {
-                      const value = formatPhone(e.target.value);
-                      setFormData((prev) => ({ ...prev, phone: value }));
-                    }}
-                  />
-                  {/* <input
-                    type="date"
-                    name="guardianBirth"
-                    value={formData.guardianBirth || ''}
-                    onChange={handleChange}
-                  /> */}
-                  {/* <label>
-                    환자 로그인 ID 동기화
-                    <input
-                      type="checkbox"
-                      name="syncPatientLoginId"
-                      checked={formData.syncPatientLoginId}
-                      onChange={handleChange}
-                    />
-                  </label> */}
-                </>
-              )}
-              {editMode === "patient" && (
-                <>
-                  <input
-                    type="text"
-                    name="name"
-                    placeholder="이름"
-                    value={formData.name}
-                    onChange={handleChange}
-                  />
-                  {/* <input
-                    type="date"
-                    name="patientBirth"
-                    value={formData.patientBirth || ''}
-                    onChange={handleChange}
-                  /> */}
-                  <input
-                    type="password"
-                    name="newPassword1"
-                    placeholder="새 비밀번호"
-                    value={formData.newPassword1}
-                    onChange={handleChange}
-                  />
-                  <input
-                    type="password"
-                    name="newPassword2"
-                    placeholder="새 비밀번호 확인"
-                    value={formData.newPassword2}
-                    onChange={handleChange}
-                  />
-                </>
-              )}
-            </form>
-            <div className="modal-actions">
-              <button type="button" onClick={handleSave}>
-                저장
-              </button>
-              <button type="button" onClick={() => setEditMode(null)}>
-                취소
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,31 +1,177 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import '../styles/Settings.css';
+import { parseLocalDate, formatLocalDate } from '../utils/date';
 
 function Settings() {
-  const [userName, setUserName] = useState('');
+  const [guardian, setGuardian] = useState(null);
+  const [patient, setPatient] = useState(null);
+  const [loading, setLoading] = useState(true);
 
+  const [editMode, setEditMode] = useState(null); // 'guardian' | 'patient' | null
+  const [formData, setFormData] = useState({});
+
+  const formatPhone = (value) => {
+    if (!value) return '';
+    value = value.replace(/[^0-9]/g, ''); // 숫자만 남김
+    if (value.length <= 3) {
+      return value;
+    } else if (value.length <= 7) {
+      return value.replace(/(\d{3})(\d{1,4})/, '$1-$2');
+    } else {
+      return value.replace(/(\d{3})(\d{4})(\d{0,4})/, '$1-$2-$3');
+    }
+  };
+
+  // 현재 로그인 정보 가져오기
   useEffect(() => {
     axios
-      .post(
-        'http://localhost:8080/dev/session/login?kakaoId=4396066259&name=kakao_user',
-        null,
-        { withCredentials: true }
-      )
-      .then(() => {
-        console.log('세션 로그인 완료');
-        return axios.get('http://localhost:8080/dev/session/getUserInfo', {
-          withCredentials: true,
-        });
+      .get(`${import.meta.env.VITE_API_URL}/api/v1/auth/check/currentinfo`, {
+        withCredentials: true,
       })
       .then((res) => {
-        console.log('세션 정보', res.data);
-        setUserName(res.data.user?.name || '');
+        console.log('세션 정보:', res.data);
+        setGuardian(res.data.data?.guardian || null);
+        setPatient(res.data.data?.patient || null);
+        console.log('guardian:', res.data.data?.guardian);
+        console.log('patient:', res.data.data?.patient);
       })
       .catch((err) => {
-        console.error('오류 발생:', err);
+        console.error('유저 정보 불러오기 실패:', err);
+      })
+      .finally(() => {
+        setLoading(false);
       });
   }, []);
+
+  useEffect(() => {
+    if (guardian && editMode === 'guardian') {
+      setFormData({
+        name: guardian.name || '',
+        phone: formatPhone(guardian.phone || ''),
+        profileImageUrl: guardian.profileImageUrl || '',
+        guardianBirth: guardian.guardianBirth
+          ? formatLocalDate(parseLocalDate(guardian.guardianBirth))
+          : '',
+        syncPatientLoginId: guardian.syncPatientLoginId || false,
+      });
+    }
+  }, [guardian, editMode]);
+
+  // 로그아웃
+  const handleLogout = async () => {
+    try {
+      await axios.post(
+        `${import.meta.env.VITE_API_URL}/api/v1/auth/logout`,
+        null,
+        { withCredentials: true }
+      );
+      alert('로그아웃 되었습니다.');
+      window.location.href = '/';
+    } catch (err) {
+      console.error('로그아웃 실패:', err);
+      alert('로그아웃에 실패했습니다.');
+    }
+  };
+
+  // 회원 탈퇴
+
+  const handleDeleteAccount = async () => {
+    const confirmed = window.confirm('정말 회원 탈퇴하시겠습니까?');
+    if (!confirmed) return;
+
+    try {
+      await axios.delete(
+        `${import.meta.env.VITE_API_URL}/api/v1/auth/guardian`,
+        { withCredentials: true }
+      );
+      alert('회원 탈퇴 완료');
+      window.location.href = '/';
+    } catch (err) {
+      alert(
+        '회원 탈퇴 실패: ' + (err.response?.data?.message || '알 수 없는 오류')
+      );
+      console.error(err);
+    }
+  };
+
+  // 수정 모달 열기
+  const openEditModal = (type) => {
+    setEditMode(type);
+
+    if (type === 'guardian' && guardian) {
+      setFormData({
+        name: guardian.name || '',
+        phone: formatPhone(guardian.phone || ''),
+        profileImageUrl: guardian.profileImageUrl || '',
+        guardianBirth: guardian.guardianBirth
+          ? formatLocalDate(parseLocalDate(guardian.guardianBirth))
+          : '',
+        syncPatientLoginId: guardian.syncPatientLoginId || false,
+      });
+    }
+    if (type === 'patient' && patient) {
+      setFormData({
+        name: patient.name || '',
+        patientBirth: patient.patientBirth
+          ? formatLocalDate(parseLocalDate(patient.patientBirth))
+          : '',
+        newPassword1: '',
+        newPassword2: '',
+      });
+    }
+  };
+
+  // 입력 변경
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  // 수정 저장
+  const handleSave = async () => {
+    try {
+      let payload = { ...formData };
+
+      // 날짜는 항상 YYYY-MM-DD 형식으로 변환
+      if (editMode === 'guardian' && formData.guardianBirth) {
+        payload.guardianBirth = formatLocalDate(
+          parseLocalDate(formData.guardianBirth)
+        );
+      }
+      if (editMode === 'patient' && formData.patientBirth) {
+        payload.patientBirth = formatLocalDate(
+          parseLocalDate(formData.patientBirth)
+        );
+      }
+
+      if (editMode === 'guardian') {
+        await axios.put(
+          `${import.meta.env.VITE_API_URL}/api/v1/auth/guardian`,
+          payload,
+          { withCredentials: true }
+        );
+        alert('보호자 정보가 수정되었습니다.');
+      } else if (editMode === 'patient') {
+        await axios.put(
+          `${import.meta.env.VITE_API_URL}/api/v1/auth/patientinfo`,
+          payload,
+          { withCredentials: true }
+        );
+        alert('환자 정보가 수정되었습니다.');
+      }
+      setEditMode(null);
+      window.location.reload(); // 수정 후 새로고침
+    } catch (err) {
+      alert('수정 실패: ' + (err.response?.data?.message || '알 수 없는 오류'));
+      console.error(err);
+    }
+  };
+
+  if (loading) return <div>로딩중...</div>;
 
   return (
     <div className="settings-wrapper">
@@ -39,35 +185,147 @@ function Settings() {
       {/* 본문 */}
       <div className="settings-page">
         <div className="profile-header">
-          <div className="profile-img-placeholder" aria-hidden="true"></div>
+          {guardian?.profileImageUrl ? (
+            <img
+              src={guardian.profileImageUrl}
+              alt="프로필"
+              className="profile-img"
+            />
+          ) : (
+            <div className="profile-img-placeholder" aria-hidden="true"></div>
+          )}
           <div className="profile-name">
-            {userName ? `${userName}님` : 'Loading...'}
+            {guardian?.name ? `${guardian.name}님` : '이름 없음'}
           </div>
         </div>
 
         <div className="settings-section">
           <div className="settings-item">
-            <div className="label">환자 정보</div>
-            <div className="arrow" aria-hidden="true">
+            <div className="label">보호자 프로필 수정</div>
+            <button
+              className="action-btn"
+              onClick={() => openEditModal('guardian')}
+            >
               ➔
-            </div>
+            </button>
+          </div>
+
+          <div className="settings-item">
+            <div className="label">환자 프로필 수정</div>
+            <button
+              className="action-btn"
+              onClick={() => openEditModal('patient')}
+            >
+              ➔
+            </button>
           </div>
 
           <div className="settings-item">
             <div className="label">로그아웃</div>
-            <div className="arrow" aria-hidden="true">
+            <button className="action-btn" onClick={handleLogout}>
               ➔
-            </div>
+            </button>
           </div>
 
           <div className="settings-item">
             <div className="label">회원탈퇴</div>
-            <div className="arrow" aria-hidden="true">
+            <button className="action-btn" onClick={handleDeleteAccount}>
               ➔
-            </div>
+            </button>
           </div>
         </div>
       </div>
+
+      {/* 모달 */}
+      {editMode && (
+        <div className="modal">
+          <div className="modal-content">
+            {console.log('✅ 렌더링 시 formData.phone:', formData.phone)}
+            <h3>
+              {editMode === 'guardian' ? '보호자 정보 수정' : '환자 정보 수정'}
+            </h3>
+            <form>
+              {editMode === 'guardian' && (
+                <>
+                  <input
+                    type="text"
+                    name="name"
+                    placeholder="이름"
+                    value={formData.name}
+                    onChange={handleChange}
+                    readOnly
+                  />
+                  <input
+                    type="text"
+                    name="phone"
+                    placeholder="전화번호"
+                    value={formData.phone || formatPhone(guardian?.phone) || ''}
+                    onChange={(e) => {
+                      const value = formatPhone(e.target.value);
+                      setFormData((prev) => ({ ...prev, phone: value }));
+                    }}
+                  />
+
+                  <input
+                    type="date"
+                    name="guardianBirth"
+                    value={formData.guardianBirth || ''}
+                    onChange={handleChange}
+                  />
+                  {/* <label>
+                    환자 로그인 ID 동기화
+                    <input
+                      type="checkbox"
+                      name="syncPatientLoginId"
+                      checked={formData.syncPatientLoginId}
+                      onChange={handleChange}
+                    />
+                  </label> */}
+                </>
+              )}
+              {editMode === 'patient' && (
+                <>
+                  <input
+                    type="text"
+                    name="name"
+                    placeholder="이름"
+                    value={formData.name}
+                    onChange={handleChange}
+                  />
+                  <input
+                    type="date"
+                    name="patientBirth"
+                    value={formData.patientBirth || ''}
+                    onChange={handleChange}
+                  />
+                  <input
+                    type="password"
+                    name="newPassword1"
+                    placeholder="새 비밀번호"
+                    value={formData.newPassword1}
+                    onChange={handleChange}
+                  />
+                  <input
+                    type="password"
+                    name="newPassword2"
+                    placeholder="새 비밀번호 확인"
+                    value={formData.newPassword2}
+                    onChange={handleChange}
+                  />
+                </>
+              )}
+            </form>
+            <div className="modal-actions">
+              <button type="button" onClick={handleSave}>
+                저장
+              </button>
+              <button type="button" onClick={() => setEditMode(null)}>
+                취소
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,25 +1,71 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 import '../styles/Settings.css';
 
 function Settings() {
+  const [userName, setUserName] = useState('');
+
+  useEffect(() => {
+    axios
+      .post(
+        'http://localhost:8080/dev/session/login?kakaoId=4396066259&name=kakao_user',
+        null,
+        { withCredentials: true }
+      )
+      .then(() => {
+        console.log('세션 로그인 완료');
+        return axios.get('http://localhost:8080/dev/session/getUserInfo', {
+          withCredentials: true,
+        });
+      })
+      .then((res) => {
+        console.log('세션 정보', res.data);
+        setUserName(res.data.user?.name || '');
+      })
+      .catch((err) => {
+        console.error('오류 발생:', err);
+      });
+  }, []);
+
   return (
-    <div className="settings-page">
-      <div className="profile-header">
-        <div className="profile-img-placeholder"></div>
-        <div className="profile-name">홍길동님</div>
+    <div className="settings-wrapper">
+      {/* 상단 고정 헤더 */}
+      <div className="settings-header">
+        <div className="header-top">
+          <div className="header-title">회원정보</div>
+        </div>
       </div>
 
-      <div className="settings-section">
-        <div className="settings-item">
-          <div className="label">닉네임</div>
-          <div className="value">복숭아 당도 최고</div>
+      {/* 본문 */}
+      <div className="settings-page">
+        <div className="profile-header">
+          <div className="profile-img-placeholder" aria-hidden="true"></div>
+          <div className="profile-name">
+            {userName ? `${userName}님` : 'Loading...'}
+          </div>
         </div>
-        <div className="settings-item">
-          <div className="label">계정</div>
-          <div className="value email">abcd@kakao.com</div>
-        </div>
-        <div className="settings-item">
-          <div className="label">로그아웃</div>
-          <div className="arrow">➔</div>
+
+        <div className="settings-section">
+          <div className="settings-item">
+            <div className="label">환자 정보</div>
+            <div className="arrow" aria-hidden="true">
+              ➔
+            </div>
+          </div>
+
+          <div className="settings-item">
+            <div className="label">로그아웃</div>
+            <div className="arrow" aria-hidden="true">
+              ➔
+            </div>
+          </div>
+
+          <div className="settings-item">
+            <div className="label">회원탈퇴</div>
+            <div className="arrow" aria-hidden="true">
+              ➔
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -63,11 +63,6 @@ const Signup = () => {
       .toUpperCase();
     const generatedPatientId = `${phoneSuffix}${randomLetters}`;
 
-    console.log("회원가입 데이터:", {
-      ...formData,
-      patientId: generatedPatientId,
-    });
-
     // 성공 후 페이지 이동
     setTimeout(() => {
       navigate("/notification"); // React Router 사용 시
@@ -82,11 +77,8 @@ const Signup = () => {
           credentials: "include", // 세션 쿠키 포함
         });
 
-        console.log("서버로부터 받은 데이터", res);
         if (res.ok) {
           const data = await res.json();
-          console.log("로그인된 유저:", data);
-          // 회원가입 추가 입력 필요하면 form 보여주기
         } else {
           alert("로그인이 필요합니다.");
         }

--- a/src/styles/DiaryCalendar.css
+++ b/src/styles/DiaryCalendar.css
@@ -127,7 +127,7 @@
 
 /* 오늘 날짜 기본 스타일: 배경 없음 + 초록 테두리 */
 .react-calendar__tile--now {
-  border: 3px solid #4caf50;
+  border: 3px solid #4caf50 !important;
   border-radius: 8px;
   background: none !important;
   color: inherit; /* 텍스트 컬러 유지 */
@@ -164,7 +164,6 @@
 
 .react-calendar__tile--active {
   background-color: #4caf50;
-  color: white;
 }
 
 /* 셀 상태 */

--- a/src/styles/Settings.css
+++ b/src/styles/Settings.css
@@ -45,13 +45,20 @@
   padding-bottom: 16px;
 }
 
+.profile-img {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #ddd;
+}
+
 .profile-img-placeholder {
   width: 64px;
   height: 64px;
   border-radius: 50%;
-  background: #f3f3f3;
+  background-color: #e9ecef;
 }
-
 .profile-name {
   font-size: 20px;
   font-weight: 700;
@@ -80,4 +87,44 @@
 .arrow {
   font-size: 18px;
   color: #b5b5b5;
+}
+
+/* 모달 기본 */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px;
+  width: 90%;
+  max-width: 400px;
+}
+
+.modal-content h3 {
+  margin-bottom: 16px;
+  font-size: 18px;
+}
+
+.modal-content input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
 }

--- a/src/styles/Settings.css
+++ b/src/styles/Settings.css
@@ -89,42 +89,59 @@
   color: #b5b5b5;
 }
 
-/* 모달 기본 */
-.modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
+/* 드롭다운 스타일 */
 
-.modal-content {
-  background: #fff;
-  border-radius: 12px;
-  padding: 20px;
-  width: 90%;
-  max-width: 400px;
-}
-
-.modal-content h3 {
-  margin-bottom: 16px;
-  font-size: 18px;
-}
-
-.modal-content input {
-  width: 100%;
-  padding: 10px;
-  margin-bottom: 12px;
+.dropdown-edit {
+  margin: 10px 0 20px 0;
+  padding: 12px;
+  background-color: white;
   border: 1px solid #ddd;
   border-radius: 8px;
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.4s ease, opacity 0.3s ease;
 }
 
-.modal-actions {
+.dropdown-edit.show {
+  max-height: 500px;
+  opacity: 1;
+}
+
+.dropdown-edit input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+.dropdown-actions {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
+}
+
+.dropdown-actions button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  background-color: #4caf50;
+  color: white;
+  font-weight: bold;
+}
+
+.dropdown-actions button:last-child {
+  background-color: #aaa;
+}
+
+input[readonly] {
+  background-color: #f0f0f0;
+  cursor: not-allowed;
+}
+
+input:not([readonly]) {
+  background-color: #ffffff;
 }

--- a/src/styles/Settings.css
+++ b/src/styles/Settings.css
@@ -1,53 +1,83 @@
-.settings-page {
-  background: #fdf9f9;
-  padding-bottom: 60px;
+/* 전체 wrapper */
+.settings-wrapper {
+  max-width: 375px;
+  margin: 0 auto;
+  background-color: #f8f9fa;
+  min-height: 100vh;
+  box-sizing: border-box;
 }
 
+/* 헤더 */
+.settings-header {
+  background: white;
+  border-bottom: 1px solid #e9ecef;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.header-top {
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #2c3e50;
+}
+
+/* 내용 영역 */
+.settings-page {
+  padding: 24px 20px;
+  color: #111;
+}
+
+/* 프로필 */
 .profile-header {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  padding: 24px 0;
+  gap: 16px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 16px;
 }
 
 .profile-img-placeholder {
-  width: 100px;
-  height: 100px;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
-  background-color: #d3d3d3;
-  border: 2px solid #ccc;
+  background: #f3f3f3;
 }
 
 .profile-name {
-  margin-top: 12px;
-  font-weight: 600;
-  font-size: 16px;
+  font-size: 20px;
+  font-weight: 700;
+  color: #333;
 }
 
+/* 설정 목록 */
 .settings-section {
-  background: white;
-  padding: 0 16px;
+  display: flex;
+  flex-direction: column;
 }
 
 .settings-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 16px 0;
-  padding: 16px 0;
-  border: 1px solid;
+  padding: 14px 0;
+  border-bottom: 1px solid #f0f0f0;
 }
 
-.settings-item:last-child {
-  border-bottom: none;
+.label {
+  font-size: 16px;
+  color: #444;
 }
 
-.value {
-  color: #111;
-  font-size: 14px;
-  font-weight: 500;
-}
-
-.value.email {
-  font-weight: bold;
+.arrow {
+  font-size: 18px;
+  color: #b5b5b5;
 }

--- a/src/styles/messageAddForm.css
+++ b/src/styles/messageAddForm.css
@@ -240,7 +240,6 @@
   min-height: 120px;
   border: 2px solid #e9ecef;
   border-radius: 12px;
-  padding: 16px;
   font-size: 16px;
   resize: vertical;
   outline: none;


### PR DESCRIPTION
## 이슈 번호
closes #7 
## 작업 개요

> 보호자/환자 정보 조회 및 수정 기능 구현
> 백엔드 연동을 통해 현재 로그인된 사용자의 정보를 불러오고, 수정 가능한 항목에 대해 업데이트 기능을 추가함

---

## 어떻게 해결했는가?

>

* 세션 기반 API(`/api/v1/auth/check/currentinfo`)로 보호자/환자 정보 불러오기
* 보호자: 이름, 생년월일, 휴대폰, 프로필 이미지 수정 가능
* 환자: 이름, 로그인 ID 수정 가능
* 수정 가능 필드는 흰 배경, 수정 불가능한 필드는 회색으로 스타일 적용
* 환자 로그인 ID 연동 여부(`syncPatientLoginId`) 상태 값 처리
* axios로 정보 수정 시 PUT 요청 API 연동 (`/update/guardian`, `/update/patient`)
* 입력값 유효성 검사 및 포맷 적용 (전화번호, 생년월일 등)

---

## 작업 체크 리스트

* [x] 현재 로그인 사용자 정보 불러오기
* [x] 보호자 정보 수정 기능 구현
* [x] 환자 정보 수정 기능 구현
* [x] 수정 가능 여부에 따라 입력 필드 스타일 구분
* [x] 유효성 검사 및 axios API 연동
* [x] 전송값 포맷 및 업데이트 상태 반영

---

## 관련 이미지 (선택)

- 보호자
<img width="440" height="764" alt="image" src="https://github.com/user-attachments/assets/4c5fc535-5401-44ab-9f12-816ab24d44b2" />

- 환자
<img width="447" height="767" alt="image" src="https://github.com/user-attachments/assets/620fe2da-af3e-46c2-8ef1-2cdc0bd0f888" />

---


## PR 전 체크 리스트

* [x] main / dev 브랜치가 아닌 기능 브랜치에서 작업했다.
* [x] 최신 dev 브랜치와 merge conflict 없이 병합했다.
* [x] 모든 기능에 대해 테스트 완료했다.
* [x] 불필요한 console.log 및 주석 제거했다.
* [x] 변수명/함수명은 팀 컨벤션에 따라 명확하게 작성했다.

---

필요하면 Diary 쪽 PR 템플릿도 같이 맞춰줄게.
